### PR TITLE
Fix missing import in camera modules

### DIFF
--- a/python_code/cams/opencv_cam.py
+++ b/python_code/cams/opencv_cam.py
@@ -1,6 +1,7 @@
 import time
 import cv2
 import numpy as np
+from multiprocessing import Event
 from .generic_cam import GenericCam
 from ..utils import display
 

--- a/python_code/cams/qimaging.py
+++ b/python_code/cams/qimaging.py
@@ -2,6 +2,7 @@
 QImaging cameras
 """
 
+from multiprocessing import Event
 from .generic_cam import GenericCam
 try:
     from .qimaging_dll import *


### PR DESCRIPTION
## Summary
- import Event from multiprocessing in the camera modules
- run static analysis to ensure modules compile

## Testing
- `python -m py_compile python_code/cams/opencv_cam.py python_code/cams/qimaging.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2', 'vimba', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686bc47c9f1c8330a21c357cc98736a9