### PR TITLE
Fix QImaging camera initialization error

### DIFF
--- a/python_code/cams/qimaging.py
+++ b/python_code/cams/qimaging.py
@@ -37,7 +37,7 @@ class QImagingCam(GenericCam):
     def _init_framebuffer(self):
         ReleaseDriver()
         LoadDriver()
-        self.cam = OpenCamera(ListCameras()[cam_id])
+        self.cam = OpenCamera(ListCameras()[self.cam_id])
         self.set_cam_settings()
         self.cam.StartStreaming()
         frame = self.cam.GrabFrame()


### PR DESCRIPTION
## Summary
- fix reference to cam_id in `qimaging.py`
- searched for other similar issues
- ran tests (failures due to missing modules)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vimba')*

------
https://chatgpt.com/codex/tasks/task_e_686bc48493ec8330a1fa82c9f34917c7